### PR TITLE
Rename contexts and register Service Worker

### DIFF
--- a/app/static/app/js/custom.js
+++ b/app/static/app/js/custom.js
@@ -1,3 +1,4 @@
+{% load static %}
 
 setTimeout(function focusMe(){
   document.getElementById("focus-here").scrollIntoView();

--- a/app/templates/latest.html
+++ b/app/templates/latest.html
@@ -1,11 +1,11 @@
 {% extends 'base.html'%}
 {% load staticfiles %}
 {% block content %}
-{% if results %}
+{% if tutorials %}
 <div class="section">
   <h3 class="title">Latest in tutorialdb </h3>
   <div class="container">
-    {% for tutorial in results %}
+    {% for tutorial in tutorials %}
     <div class="box">
       <a href="{{ tutorial.link }}" target="_blank" id="tutorial-tag">{{ tutorial.title }}</a>
       <div class="tile">

--- a/app/templates/search_results.html
+++ b/app/templates/search_results.html
@@ -2,12 +2,12 @@
 {% load staticfiles %}
 {% block results %}
 <div id="focus-here">
-{% if object_list %}
+{% if tutorials %}
   <div class="section">
-    <h3 class="subtitle">Search Results for "{{ tquery }}"</h3>
+    <h3 class="subtitle">Search Results for "{{ query }}"</h3>
     <p>About {{ total }} results ({{ time }} seconds)</p><br>
     <div class="container">
-    {% for tutorial in object_list %}
+    {% for tutorial in tutorials %}
       <div class="box">
         <a href="{{ tutorial.link }}" target="_blank" id="tutorial-tag">{{ tutorial.title }}</a>
         <div class="tile">
@@ -25,21 +25,21 @@
   </div>
   <div class="section">
     <div class="container">
-    {% if object_list.has_other_pages %}
+    {% if tutorials.has_other_pages %}
       <nav class="pagination is-rounded" role="navigation" aria-label="pagination">
-      {% if object_list.has_previous %}
-        <a class="pagination-previous" href="?page={{ object_list.previous_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.category %}&category={{ request.GET.category }}{% endif %}">Previous</a>
+      {% if tutorials.has_previous %}
+        <a class="pagination-previous" href="?page={{ tutorials.previous_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.category %}&category={{ request.GET.category }}{% endif %}">Previous</a>
       {% else %}
         <a class="pagination-previous" href="#!" title="This is the first page" disabled >Previous</a>
       {% endif %}
-      {% if object_list.has_next %}
-        <a href="?page={{ object_list.next_page_number }}{% if request.GET.q %}&q={{request.GET.q }}{% endif %}{% if request.GET.category %}&category={{ request.GET.category}}{% endif %}" class="pagination-next">Next page</a>
+      {% if tutorials.has_next %}
+        <a href="?page={{ tutorials.next_page_number }}{% if request.GET.q %}&q={{request.GET.q }}{% endif %}{% if request.GET.category %}&category={{ request.GET.category}}{% endif %}" class="pagination-next">Next page</a>
       {% else %}
         <a class="pagination-next" href="#!" disabled >Next</a>
       {% endif %}
         <ul class="pagination-list">
-        {% for num in object_list.paginator.page_range %}
-          {% if object_list.number == num %}
+        {% for num in tutorials.paginator.page_range %}
+          {% if tutorials.number == num %}
           <li><a class="pagination-link" href="#!">{{ num }}</a></li>
           {% else %}
           <li><a class="pagination-link" href="?page={{ num }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.category %}&category={{ request.GET.category }}{% endif %}" >{{ num }}</a></li>

--- a/app/templates/taglinks.html
+++ b/app/templates/taglinks.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 {% load staticfiles %}
-{% if object_list %}
+{% if tutorials %}
 <div class="section">
   <h2 class="title is-4">Tutorials Tagged 
     <span class="box tag">
@@ -9,7 +9,7 @@
     </span>
   </h2>
   <div class="container">
-  {% for tutorial in object_list %}
+  {% for tutorial in tutorials %}
     <div class="box">
         <a href="{{ tutorial.link }}" target="_blank" id="tutorial-tag">{{ tutorial.title }}</a>
         <div class="tile">

--- a/app/templates/tags.html
+++ b/app/templates/tags.html
@@ -4,8 +4,8 @@
 <div class="section">
   <div class="container">
     <h2 class="title is-1">Tags</h2>
-    {% if object_list %}
-    {% for tag in object_list %}
+    {% if tags %}
+    {% for tag in tags %}
       <span class="tag box" name="colorpad">
           <a href="{% url 'app:tag-links' tag.name %}" class="title is-5">📌 {{ tag.name }}</a>
       </span>&nbsp;

--- a/app/views.py
+++ b/app/views.py
@@ -16,8 +16,8 @@ def latest(request):
 	"""
 	View for the latest tutorial entries.
 	"""
-	results = tutorial.objects.all().order_by('-id')[:10]
-	context = {'results': results, 'title': 'Latest'}
+	tutorials = tutorial.objects.all().order_by('-id')[:10]
+	context = {'tutorials': tutorials, 'title': 'Latest'}
 	return render(request, 'latest.html', context)
 
 def about(request):
@@ -37,29 +37,29 @@ def search_query(request):
 	start_time = time.time()
 
 	if category is not None:
-		object_list = tutorial.objects.filter(
+		tutorials = tutorial.objects.filter(
 			(Q(title__icontains=query) | Q(tags__name__in=list_query)) & Q(category__icontains=category)
 		).order_by('id').distinct()
 	else:
-		object_list = tutorial.objects.filter(
+		tutorials = tutorial.objects.filter(
 			(Q(title__icontains=query) & Q(tags__name__in=list_query))
 		).order_by('id').distinct()
 	end_time = time.time()
-	total = len(object_list)
+	total = len(tutorials)
 	result_time = round(end_time - start_time, 3)
 
-	paginator = Paginator(object_list, 3)
+	paginator = Paginator(tutorials, 3)
 	page = request.GET.get('page')
 	try:
-		object_list = paginator.page(page)
+		tutorials = paginator.page(page)
 	except PageNotAnInteger:
-		object_list = paginator.page(1)
+		tutorials = paginator.page(1)
 	except EmptyPage:
-		object_list = paginator.page(paginator.num_pages)
+		tutorials = paginator.page(paginator.num_pages)
 
 	context = {
-		'tquery':query, 
-		'object_list':object_list, 
+		'query':query, 
+		'tutorials':tutorials, 
 		'total': total, 
 		'time': result_time, 
 		'title': query
@@ -104,8 +104,8 @@ def tags(request):
 	"""
 	View for the tags.
 	"""
-	object_list = tag.objects.all()
-	context = {'object_list':object_list, 'title': 'Tags'}
+	tags = tag.objects.all()
+	context = {'tags':tags, 'title': 'Tags'}
 	return render(request, 'tags.html', context)
 
 def taglinks(request, tagname):
@@ -114,6 +114,6 @@ def taglinks(request, tagname):
 	"""
 	taglist = []
 	taglist.append(tagname)
-	object_list = tutorial.objects.filter(tags__name__in = taglist)
-	context = {'tag': tagname, 'object_list':object_list, 'title': tagname}
+	tutorials = tutorial.objects.filter(tags__name__in = taglist)
+	context = {'tag': tagname, 'tutorials':tutorials, 'title': tagname}
 	return render(request, 'taglinks.html', context)


### PR DESCRIPTION
>Used the static template tag in custom.js to properly register Service Worker.
>Renamed contexts named 'object_list' to more representative names in view.py and their respective >templates.

Fix for #14.

__`SW.js`__ no longer gives __404 error__.