### PR TITLE
ContributeView redirect, Select options fix.

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path('api/', include('api.urls'), name='api'),
     path('contribute/', ContributeView.as_view(), name='contribute'),
     path('tags/', views.tags, name='tags'),
-    path('thankyou/', ContributeView.as_view(), name='thankyou'),
+    path('thankyou/', views.thanks, name='thankyou'),
     path('about', views.about, name='about'),
     path('tags/tag=<tagname>', views.taglinks, name='tag-links'),
 ]

--- a/app/views.py
+++ b/app/views.py
@@ -71,7 +71,8 @@ def search_query(request):
 		'tutorials':tutorials, 
 		'total': total, 
 		'time': result_time, 
-		'title': query
+		'title': query,
+		'categories': tutorial.CATEGORIES
 	}
 
 	return render(request, 'search_results.html', context)

--- a/app/views.py
+++ b/app/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.views.generic import TemplateView
 from .models import tag, tutorial
 from django.db.models import Q
@@ -115,8 +115,8 @@ class ContributeView(TemplateView):
 
 				tagObjList = tag.objects.filter(name__in = tags)
 				tutorialObject.tags.set(tagObjList)
-				return render(request, 'thankyou.html', {'title': 'Thanks'})
-		return render(request, 'thankyou.html', {'title': 'Thanks'})
+				return redirect('app:thankyou')
+		return redirect('app:thankyou')
 
 def tags(request):
 	"""
@@ -142,3 +142,6 @@ def taglinks(request, tagname):
 		'title': tagname
 	}
 	return render(request, 'taglinks.html', context)
+
+def thanks(request):
+	return render(request, 'thankyou.html', {'title': 'Thanks'})


### PR DESCRIPTION
Possible fix for #17 and the bug introduced in #24 where the select box options don't appear in the `search_results.hmtl` template.

Apparently templates don't inherit the contexts passed to the base template.

Now, whenever you successfully POST a tutorial, you get properly redirected to the `/thankyou/` page.