### PR TITLE
Implemented the caching db query for tags page

### DIFF
--- a/app/cache_constants.py
+++ b/app/cache_constants.py
@@ -1,0 +1,6 @@
+"""
+List of all Cache key constants.
+"""
+
+ALL_TAGS = "ALL_TAGS"
+    

--- a/app/views.py
+++ b/app/views.py
@@ -1,11 +1,13 @@
 import time
 
+from django.core.cache import cache
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Q
 from django.shortcuts import render
 from django.views.generic import TemplateView
 from taggie.parser import generate_tags
 from .models import Tag, Tutorial
+from . import cache_constants
 
 
 class HomePageView(TemplateView):
@@ -73,7 +75,7 @@ def latest(request):
 
 def tags(request):
     """view for the tags"""
-    tags = Tag.objects.all()
+    tags = cache.get_or_set(cache_constants.ALL_TAGS, Tag.objects.all(), None)
     context = {
         'tags': tags,
         'title': 'Tags'
@@ -140,6 +142,9 @@ class ContributeView(TemplateView):
 
                 tag_obj_list = Tag.objects.filter(name__in=tags)
                 tutorial_object.tags.set(tag_obj_list)
+
+                # clearing the all tags cache
+                cache.delete(cache_constants.ALL_TAGS)
         # thankyou.html shouldn't be accessible unless someone successfully posts
         # a tutorial
                 return render(request, 'thankyou.html', {'title': 'Thanks!'})


### PR DESCRIPTION
- Implemented the caching for query all the tags in tags page
- Added the cache_constant.py file since we need to use the same cache in multiple places.
- Currently used in-memory cache. But in the future, it can extended to the external caching system like Redis or Memcached with simple configurations in setting.py file like this

```python
CACHES = {
    'default': {
        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
        'LOCATION': '127.0.0.1:11211',
    }
}
```
