### PR TITLE
LOCAL_HOST has been made optional

### DIFF
--- a/tutorialdb/settings.py
+++ b/tutorialdb/settings.py
@@ -1,4 +1,5 @@
 import os
+import dj_database_url
 
 from dotenv import load_dotenv
 load_dotenv()
@@ -8,14 +9,21 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 SECRET_KEY = os.environ['SECRET_KEY']
 
+try:
+    LOCAL_HOST = os.environ['LOCAL_HOST'] # your local IP to test the site on your network
+except:
+    LOCAL_HOST = None
+
 DEBUG = True
 
 ALLOWED_HOSTS = [
     '127.0.0.1',
-    os.environ['LOCAL_HOST'], # your local IP to test the site on your network,
     'tutorialdb.pythonanywhere.com',
-    'tutorialdb-app.herokuapp.com'
+    'tutorialdb-app.herokuapp.com',
 ]
+
+if LOCAL_HOST:
+    ALLOWED_HOSTS.append(LOCAL_HOST)
 
 # Application definition
 
@@ -118,8 +126,10 @@ USE_L10N = True
 
 USE_TZ = True
 
-STATIC_URL = '/static/'
 PROJECT_ROOT = os.path.join(os.path.abspath(__file__))
+
+# Location of all static files
+STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'staticfiles')
 
 # Extra lookup directories for collectstatic to find static files
@@ -129,6 +139,5 @@ STATICFILES_DIRS = (
 
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
-import dj_database_url 
 prod_db  =  dj_database_url.config(conn_max_age=500)
 DATABASES['default'].update(prod_db)


### PR DESCRIPTION
README.md mentioned that LOCAL_HOST was optional but it actually wasn't.
Added conditional statements to make it optional.
Changed position of PROJECT_ROOT to make sure that all the variables
related to static files are found one after the other.
Moved an import statement from the bottom to the top to keep all imports
in the same place.

Picture1 shows the output you get when running the command 'python3 manage.py'
Picture2 shows the output you get after adding the conditional statements

![Picture1](https://user-images.githubusercontent.com/47667852/84595089-b9ce5280-ae73-11ea-836b-a3755682cd85.png)
![Picture2](https://user-images.githubusercontent.com/47667852/84595087-b89d2580-ae73-11ea-8a49-e92f7ec269d6.png)

