### PR TITLE
 feat: implementa Tag.published_tutorials_count (M2) e corrige settings.py except (N)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+SECRET_KEY=django-insecure-local-dev-key-es2-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           pip install -r requirements.txt
           
       - name: Run Tests and generate Coverage
+        env:
+          SECRET_KEY: temporary-secret-key-for-testing
         run: |
           pytest --cov=. --cov-report=xml
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test-and-sonar:
+    name: Test and SonarCloud Scan
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          
+      - name: Run Tests and generate Coverage
+        run: |
+          pytest --cov=. --cov-report=xml
+          
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,6 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -22,59 +22,48 @@
 - All the content (tutorials) is owned by the respective authors/sites.
 - tutorialdb maintains its own database saving the links to tutorials and some meta info.
 
-### Installation 🔮
+### Installation & Execution 🔮
 
-1. Create virtual environment.
+1. Create a virtual environment:
 
 	**Linux/MacOS**
 	```bash
-	virtualenv -p python3 venv && cd venv && source bin/activate
+	python3 -m venv venv && source venv/bin/activate
 	```
-	**Windows**
-	(*PowerShell*)
-	```cmd
-	py -m venv venv; .\venv\Scripts\activate;
+	**Windows (PowerShell)**
+	```powershell
+	python -m venv venv
+	.\venv\Scripts\activate
+	```
+	*(Note: If you get execution policy errors on Windows, run `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process` first).*
+
+2. Clone the repository and navigate to it.
+
+3. Install dependencies:
+	```bash
+	pip install -r requirements.txt
+	```
+	*(Note: We updated the dependencies so that `psycopg2-binary` is used on Windows instead of the source version, preventing compilation issues).*
+
+4. Set up Environment Variables:
+	- The repository already comes with a default `.env` file containing a `SECRET_KEY` for development, so no manual configuration is required to start!
+
+5. Run Migrations:
+	```bash
+	python manage.py migrate
 	```
 
-2. Clone the repository.
-
-```bash
-git clone https://github.com/Bhupesh-V/tutorialdb.git
-```    
-
-3. Install dependencies.
-
-```bash
-pip install -r requirements.txt
-```
-
-4. Set-up virtual environment variables.
-	1. Create a file named `.env` in the root directory & add the following contents.
-	
-	```text
-	SECRET_KEY = 'my-secret-key'
-	LOCAL_HOST = 'my-local-ip'
+6. Run Tests and Coverage:
+	To run the test suite and output the coverage report directly on the terminal, run:
+	```bash
+	pytest --cov=. --cov-report=term-missing
 	```
-	2. For `SECRET_KEY` use [Django Secret Key Generator](https://www.miniwebtool.com/django-secret-key-generator/) or [Djecrety](https://djecrety.ir/).
-	3. Adding `LOCAL_HOST` is optional.
 
-5. Migrate tables.
-
-```bash
-python manage.py migrate
-```
-
-6. Run Tests.
-
-```bash
-python manage.py test
-```
-
-7. Run the development server.
-
-```bash
-python manage.py runserver
-```
+7. Run the Development Server:
+	```bash
+	python manage.py runserver
+	```
+	Open your browser at `http://127.0.0.1:8000/`.
 
 ## 📝 License
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -4,13 +4,13 @@ from django.test import TransactionTestCase
 class APITests(TransactionTestCase):
 
     def test_tutorials_page_status_code(self):
-        response = self.client.get('/tutorials/')
-        self.assertEquals(response.status_code, 200)
+        response = self.client.get('/api/tutorials/')
+        self.assertEqual(response.status_code, 200)
 
     def test_tags_page_status_code(self):
-        response = self.client.get('/tags/')
-        self.assertEquals(response.status_code, 200)
+        response = self.client.get('/api/tags/')
+        self.assertEqual(response.status_code, 200)
 
     def test_latest_page_status_code(self):
-        response = self.client.get('/latest/')
-        self.assertEquals(response.status_code, 200)
+        response = self.client.get('/api/latest/')
+        self.assertEqual(response.status_code, 200)

--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,10 @@ class Tag(models.Model):
     def __str__(self):
         return self.name
 
+    def published_tutorials_count(self):
+        """Returns the number of published tutorials associated with this tag"""
+        return self.tutorial_set.filter(publish=True).count()
+
 
 class Tutorial(models.Model):
     """tutorials have a title, a URL, a set of tags, a category and creation date"""

--- a/app/models.py
+++ b/app/models.py
@@ -20,6 +20,7 @@ class Tutorial(models.Model):
     COURSE = 'course'
     DOCS = 'docs'
     VIDEO = 'video'
+    PODCAST = 'podcast'
 
     CATEGORIES = (
         (ARTICLE, 'Article'),
@@ -28,6 +29,7 @@ class Tutorial(models.Model):
         (COURSE, 'Course'),
         (DOCS, 'Documentation'),
         (VIDEO, 'Video'),
+        (PODCAST, 'Podcast'),
     )
 
     title = models.CharField(max_length=200)
@@ -39,3 +41,7 @@ class Tutorial(models.Model):
 
     def __str__(self):
         return self.title
+
+    def is_published(self):
+        """Returns True if the tutorial is published"""
+        return self.publish

--- a/app/static/app/js/custom.js
+++ b/app/static/app/js/custom.js
@@ -17,9 +17,7 @@ function share(title, link) {
 }
 
 function checkEmpty() {
-	var input = document.getElementById("search-bar");
-	if (input.value === "" || input.value === null) {
-		return false;
-	}
-	return true;
+    var input = document.getElementById("search-bar");
+    
+    return input.value !== "" && input.value !== null;
 }

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -1,5 +1,5 @@
 {% extends 'base.html'%}
-{% load staticfiles %}
+{% load static %}
 {% block content %}
 <section class="hero is-medium is-primary is-bold">
   <div class="hero-body">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html>
   <head>

--- a/app/templates/contribute.html
+++ b/app/templates/contribute.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block content %}
 <section class="hero is-medium is-primary is-bold">
   <div class="hero-body">

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block content %}
 <section class="hero is-medium is-dark is-bold">
   <div class="hero-body" style="background-color: #04243B">

--- a/app/templates/latest.html
+++ b/app/templates/latest.html
@@ -1,5 +1,5 @@
 {% extends 'base.html'%}
-{% load staticfiles %}
+{% load static %}
 {% block content %}
 {% if tutorials %}
 <div class="section">

--- a/app/templates/search_results.html
+++ b/app/templates/search_results.html
@@ -1,5 +1,5 @@
 {% extends 'home.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block results %}
 <div id="focus-here">
 {% if tutorials %}

--- a/app/templates/taglinks.html
+++ b/app/templates/taglinks.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-{% load staticfiles %}
+{% load static %}
 {% if tutorials %}
 <div class="section">
   <h2 class="title is-4">Tutorials Tagged 

--- a/app/templates/tags.html
+++ b/app/templates/tags.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% block content %}
 <div class="section">
   <div class="container">

--- a/app/templates/thankyou.html
+++ b/app/templates/thankyou.html
@@ -1,5 +1,5 @@
 {% extends 'base.html'%}
-{% load staticfiles %}
+{% load static %}
 {% block content %}
 <center>
   <section class="hero is-medium is-primary is-bold">

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from app.models import Tag, Tutorial
+
+class TagModelTest(TestCase):
+    def test_string_representation(self):
+        tag = Tag(name="Python")
+        self.assertEqual(str(tag), tag.name)
+
+class TutorialModelTest(TestCase):
+    def setUp(self):
+        self.tutorial = Tutorial(
+            title="Learn Django",
+            link="https://docs.djangoproject.com/",
+            category=Tutorial.DOCS,
+            publish=True
+        )
+        self.tutorial.save()
+
+    def test_string_representation(self):
+        self.assertEqual(str(self.tutorial), self.tutorial.title)
+
+    def test_is_published(self):
+        self.assertTrue(self.tutorial.is_published())
+
+    def test_not_published(self):
+        draft = Tutorial(
+            title="Draft",
+            link="http://example.com",
+            category=Tutorial.ARTICLE,
+            publish=False
+        )
+        draft.save()
+        self.assertFalse(draft.is_published())

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -6,6 +6,27 @@ class TagModelTest(TestCase):
         tag = Tag(name="Python")
         self.assertEqual(str(tag), tag.name)
 
+    def test_published_tutorials_count(self):
+        tag = Tag.objects.create(name="Django")
+        
+        t1 = Tutorial.objects.create(
+            title="Django Tutorial 1",
+            link="https://example.com/1",
+            category=Tutorial.DOCS,
+            publish=True
+        )
+        t1.tags.add(tag)
+        
+        t2 = Tutorial.objects.create(
+            title="Django Tutorial 2",
+            link="https://example.com/2",
+            category=Tutorial.DOCS,
+            publish=False
+        )
+        t2.tags.add(tag)
+        
+        self.assertEqual(tag.published_tutorials_count(), 1)
+
 class TutorialModelTest(TestCase):
     def setUp(self):
         self.tutorial = Tutorial(

--- a/app/tests/test_views.py
+++ b/app/tests/test_views.py
@@ -5,30 +5,30 @@ class StaticPageTests(SimpleTestCase):
 
     def test_home_page_status_code(self):
         response = self.client.get('/')
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_api_page_status_code(self):
         response = self.client.get('/api/')
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_about_page_status_code(self):
         response = self.client.get('/about/')
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_contribute_page_status_code(self):
         response = self.client.get('/contribute/')
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
 
 class DynamicPageTests(TransactionTestCase):
 
     def test_latest_page_status_code(self):
         response = self.client.get('/latest/')
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_tags_page_status_code(self):
         response = self.client.get('/tags/')
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
 
 class TestTemplateNames(TransactionTestCase):

--- a/app/views.py
+++ b/app/views.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Q
 from django.shortcuts import render
+from django.views.decorators.http import require_GET
 from django.views.generic import TemplateView
 from taggie.parser import generate_tags
 from .models import Tag, Tutorial
@@ -21,6 +22,7 @@ class HomePageView(TemplateView):
         return self.context
 
 
+@require_GET
 def search_query(request):
     """view for the search results"""
     query = request.GET.get('q').lower()
@@ -64,6 +66,7 @@ def search_query(request):
     return render(request, 'search_results.html', context)
 
 
+@require_GET
 def latest(request):
     """view for the latest tutorial entries"""
     tutorials = Tutorial.objects.all().filter(publish=True).order_by('-id')[:10]
@@ -74,6 +77,7 @@ def latest(request):
     return render(request, 'latest.html', context)
 
 
+@require_GET
 def tags(request):
     """view for the tags"""
     tags = cache.get_or_set(cache_constants.ALL_TAGS, Tag.objects.all(), None)
@@ -84,6 +88,7 @@ def tags(request):
     return render(request, 'tags.html', context)
 
 
+@require_GET
 def taglinks(request, tagname):
     """view for the tutorials with the {tagname}"""
     taglist = []
@@ -97,6 +102,7 @@ def taglinks(request, tagname):
     return render(request, 'taglinks.html', context)
 
 
+@require_GET
 def about(request):
     """about view"""
     return render(request, 'about.html', {'title': 'About'})

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = tutorialdb.settings
+python_files = tests.py test_*.py *_tests.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ lxml>=4.4.0
 djangorestframework>=3.10.0
 python-dotenv>=0.10.0
 django-import-export>=1.0.0
-whitenoise==3.3.1
+whitenoise>=6.0.0
 dj-database-url==0.4.2
 gunicorn==19.7.1
 psycopg2-binary>=2.7.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ whitenoise==3.3.1
 dj-database-url==0.4.2
 gunicorn==19.7.1
 psycopg2==2.7.3.2
+pytest>=7.0.0
+pytest-django>=4.5.2
+pytest-cov>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-import-export>=1.0.0
 whitenoise==3.3.1
 dj-database-url==0.4.2
 gunicorn==19.7.1
-psycopg2==2.7.3.2
+psycopg2-binary>=2.7.3.2
 pytest>=7.0.0
 pytest-django>=4.5.2
 pytest-cov>=4.0.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=PedroVFSantos_tutorialdb_ES2
+sonar.organization=pedrovfsantos
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.sources=app
+sonar.tests=app/tests
+sonar.language=py

--- a/tutorialdb/settings.py
+++ b/tutorialdb/settings.py
@@ -14,7 +14,7 @@ try:
 except:
     LOCAL_HOST = None
 
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = [
     '127.0.0.1',

--- a/tutorialdb/settings.py
+++ b/tutorialdb/settings.py
@@ -137,7 +137,7 @@ STATICFILES_DIRS = (
     os.path.join(PROJECT_ROOT, 'static'),
 )
 
-STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 prod_db  =  dj_database_url.config(conn_max_age=500)
 DATABASES['default'].update(prod_db)

--- a/tutorialdb/settings.py
+++ b/tutorialdb/settings.py
@@ -11,7 +11,7 @@ SECRET_KEY = os.environ['SECRET_KEY']
 
 try:
     LOCAL_HOST = os.environ['LOCAL_HOST'] # your local IP to test the site on your network
-except:
+except KeyError:
     LOCAL_HOST = None
 
 DEBUG = False

--- a/tutorialdb/settings.py
+++ b/tutorialdb/settings.py
@@ -126,7 +126,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-PROJECT_ROOT = os.path.join(os.path.abspath(__file__))
+PROJECT_ROOT = BASE_DIR
 
 # Location of all static files
 STATIC_URL = '/static/'


### PR DESCRIPTION
    Este Pull Request conclui as etapas restantes do projeto prático de Engenharia de
  Software II, contendo a implementação da segunda mudança independente (#M2) e a
  correção da issue individual do SonarCloud (#N), além de ajustes essenciais para
  compatibilidade do ambiente local.

    1. Requisito #M2 (Segunda Mudança Independente)
   * Funcionalidade: Adicionado o método published_tutorials_count() ao model Tag
  (app/models.py) para contabilizar dinamicamente os tutoriais publicados de cada tag.
   * Testes: Implementado o caso de teste test_published_tutorials_count no arquivo
  app/tests/test_models.py para validar o comportamento esperado.

    2. Requisito #N (Correção de Issue do SonarCloud)
   * Issue Corrigida: python:S5754 (Specify an exception class to catch or reraise the
  exception).
   * Solução: Substituído o bloco genérico "except:" por "except KeyError:" na leitura
  da variável de ambiente LOCAL_HOST em tutorialdb/settings.py, evitando a captura
  oculta de exceções inesperadas.

    3. Ajustes de Compatibilidade e Correção de Testes
   * Compatibilidade do Django (versão 6.x): Substituído {% load staticfiles %} por {%
  load static %} em todos os templates sob app/templates/, pois o módulo antigo foi
  removido.
   * Correções na Suíte de Testes:
      - Atualizado o método deprecated assertEquals para assertEqual em
  api/tests/test_views.py.
      - Corrigidos os caminhos de URL (/api/) dentro dos testes da API para sanar os
  erros de 404 Not Found ocorridos na suíte.
   * Configuração de Estáticos e Hosts:
      - Corrigido o PROJECT_ROOT para referenciar BASE_DIR de forma adequada em 
  settings.py.
      - Adicionado 'localhost' ao ALLOWED_HOSTS do Django para facilitar a visualização
  e execução local.

    Todos os 20 testes unitários e de integração foram validados e estão passando com sucesso localmente.